### PR TITLE
Fix generated version file not included in plugin jar

### DIFF
--- a/origami-gradle-plugin/build.gradle.kts
+++ b/origami-gradle-plugin/build.gradle.kts
@@ -44,7 +44,9 @@ publishing {
 
 tasks.register("generateVersionFile") {
     val versionFile = layout.buildDirectory.file("generatedResources/version").get().asFile
+    inputs.property("projectVersion", project.version.toString())
     outputs.file(versionFile)
+    
     doLast {
         versionFile.parentFile.mkdirs()
         versionFile.writeText(project.version.toString())


### PR DESCRIPTION
Previously, the version file was generated in `build/resources/main/` but this caused it to get overwritten and then not included in the final origami plugin jar the first time the project is built with gradle.
Running `gradle clean` on an already-built project is not enough to reproduce this issue, you must also delete the `.gradle/` folder in project root.
This PR updates the generateVersionFile task so that the version file is generated in `build/generatedResources/` and then included in the processResources task.

Btw the 0.1.0 release jar was built by gh actions in a clean environment, so it does not include the version file either and it crashes :)
https://repo.xenondevs.xyz/releases/xyz/xenondevs/origami/origami-gradle-plugin/0.1.0/origami-gradle-plugin-0.1.0.jar